### PR TITLE
Enable logging for load balancers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,11 @@ resource "google_compute_backend_service" "lb_backend" {
   }
 
   health_checks = [var.health_check_self_link]
+
+  log_config {
+    enable      = true
+    sample_rate = var.logging_sample_rate
+  }
 }
 
 resource "google_compute_url_map" "lb_url_map" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,5 +51,16 @@ variable "redirect_http_to_https" {
 variable "security_policy_id" {
   description = "The Cloud Armor security policy to use for the backend service"
   type        = string
-  default = "" 
+  default     = ""
+}
+
+variable "logging_sample_rate" {
+  description = "The sample rate for load balancer logging. Must be between 0.0 and 1.0"
+  type        = number
+  default     = 1.0
+
+  validation {
+    condition     = var.logging_sample_rate >= 0.0 && var.logging_sample_rate <= 1.0
+    error_message = "The logging sample rate must be between 0.0 and 1.0."
+  }
 }


### PR DESCRIPTION
Required for ISO compliance as directed by Vanta.

This enables logging of requests on our load balancers for Snowplow.

[SP-9758](https://zitcha.atlassian.net/browse/SP-9758)

[SP-9758]: https://zitcha.atlassian.net/browse/SP-9758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ