### PR TITLE
SP-13119: Add CODEOWNERS with platform-team ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Platform Team owns all infrastructure
+* @zitcha/platform-team


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` file with `@zitcha/platform-team` as owner of all files
- Ensures Platform Team is automatically requested for review on PRs

[SP-13119](https://zitcha.atlassian.net/browse/SP-13119)

[SP-13119]: https://zitcha.atlassian.net/browse/SP-13119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ